### PR TITLE
[Draft] Add minimal proof-of-work implementation (Issue #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Used for testing
+
+## Bounty #22 Progress (Proof-of-Work)
+
+Added a minimal, reviewable PoW implementation:
+
+- `pow.ts`
+  - `calculatePowHash(...)`
+  - `isValidPow(...)`
+  - `mineProofOfWork(...)`
+- `pow-demo.ts`
+  - runnable example that mines a block with configurable difficulty
+
+### Quick run
+
+```bash
+bun run pow-demo.ts
+```
+
+This is an incremental slice meant for review before wiring into a full blockchain loop.

--- a/pow-demo.ts
+++ b/pow-demo.ts
@@ -1,0 +1,17 @@
+import { mineProofOfWork, isValidPow } from "./pow";
+
+const difficulty = 3;
+const payload = {
+  index: 1,
+  previousHash: "0".repeat(64),
+  timestamp: Date.now(),
+  data: "genesis-transaction",
+};
+
+const result = mineProofOfWork(payload, difficulty);
+
+if (!isValidPow(result.hash, difficulty)) {
+  throw new Error("PoW validation failed");
+}
+
+console.log(JSON.stringify({ difficulty, ...result }, null, 2));

--- a/pow.ts
+++ b/pow.ts
@@ -1,0 +1,44 @@
+import crypto from "crypto";
+
+export interface PowInput {
+  index: number;
+  previousHash: string;
+  timestamp: number;
+  data: string;
+  nonce: number;
+}
+
+export function sha256(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+export function calculatePowHash(input: PowInput): string {
+  return sha256(
+    `${input.index}|${input.previousHash}|${input.timestamp}|${input.data}|${input.nonce}`
+  );
+}
+
+export function isValidPow(hash: string, difficulty: number): boolean {
+  if (difficulty < 0) return false;
+  return hash.startsWith("0".repeat(difficulty));
+}
+
+export function mineProofOfWork(
+  payload: Omit<PowInput, "nonce">,
+  difficulty: number,
+  maxIterations = 5_000_000
+): { nonce: number; hash: string; iterations: number } {
+  let nonce = 0;
+
+  while (nonce < maxIterations) {
+    const hash = calculatePowHash({ ...payload, nonce });
+    if (isValidPow(hash, difficulty)) {
+      return { nonce, hash, iterations: nonce + 1 };
+    }
+    nonce += 1;
+  }
+
+  throw new Error(
+    `Unable to find valid nonce within maxIterations=${maxIterations}`
+  );
+}


### PR DESCRIPTION
## What this PR adds

This draft PR provides a minimal, reviewable implementation for Issue #22 (proof-of-work algorithm):

- `pow.ts`: SHA-256 based PoW helpers
  - `calculatePowHash(...)`
  - `isValidPow(...)`
  - `mineProofOfWork(...)`
- `pow-demo.ts`: runnable demo that mines a valid nonce
- README update with run instructions

## Why this scope

This is intentionally a small first slice to make review easy before integrating into full block creation and chain validation flow.

## Verification

```bash
bun run pow-demo.ts
```

Expected output includes a hash prefixed with required zeros.

Closes #22
