### PR TITLE
[Draft] Add minimal block creation + validation flow (Issue #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Used for testing
+
+## Bounty #23 Progress (Block Creation + Validation)
+
+Added a minimal, reviewable block lifecycle implementation:
+
+- `blockchain.ts`
+  - `mineBlock(...)`
+  - `validateBlock(...)`
+  - `validateChain(...)`
+- `blockchain-demo.ts`
+  - mines two connected blocks and validates the chain
+
+### Quick run
+
+```bash
+bun run blockchain-demo.ts
+```
+
+This is the first reviewable slice before adding networking/mempool rules.

--- a/blockchain-demo.ts
+++ b/blockchain-demo.ts
@@ -1,0 +1,44 @@
+import { mineBlock, validateChain, type Block } from "./blockchain";
+
+const difficulty = 2;
+
+const genesis: Block = mineBlock(
+  {
+    index: 0,
+    previousHash: "0".repeat(64),
+    timestamp: Date.now(),
+    transactions: [{ from: "network", to: "minerA", amount: 50 }],
+  },
+  difficulty
+);
+
+const second = mineBlock(
+  {
+    index: 1,
+    previousHash: genesis.hash,
+    timestamp: Date.now() + 1,
+    transactions: [
+      { from: "minerA", to: "walletB", amount: 3 },
+      { from: "walletC", to: "walletA", amount: 5 },
+    ],
+  },
+  difficulty
+);
+
+const result = validateChain([genesis, second], difficulty);
+if (!result.valid) {
+  throw new Error(`Chain validation failed at ${result.failedAt}: ${result.reason}`);
+}
+
+console.log(
+  JSON.stringify(
+    {
+      difficulty,
+      genesis: { index: genesis.index, hash: genesis.hash, nonce: genesis.nonce },
+      second: { index: second.index, hash: second.hash, nonce: second.nonce },
+      validation: result,
+    },
+    null,
+    2
+  )
+);

--- a/blockchain.ts
+++ b/blockchain.ts
@@ -1,0 +1,99 @@
+import crypto from "crypto";
+
+export interface Transaction {
+  from: string;
+  to: string;
+  amount: number;
+}
+
+export interface Block {
+  index: number;
+  previousHash: string;
+  timestamp: number;
+  transactions: Transaction[];
+  nonce: number;
+  hash: string;
+}
+
+export function sha256(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+export function calculateBlockHash(input: Omit<Block, "hash">): string {
+  return sha256(
+    `${input.index}|${input.previousHash}|${input.timestamp}|${JSON.stringify(
+      input.transactions
+    )}|${input.nonce}`
+  );
+}
+
+export function mineBlock(
+  base: Omit<Block, "nonce" | "hash">,
+  difficulty = 2,
+  maxIterations = 2_000_000
+): Block {
+  let nonce = 0;
+
+  while (nonce < maxIterations) {
+    const candidate = { ...base, nonce };
+    const hash = calculateBlockHash(candidate);
+    if (hash.startsWith("0".repeat(difficulty))) {
+      return { ...candidate, hash };
+    }
+    nonce += 1;
+  }
+
+  throw new Error(
+    `Unable to mine block within maxIterations=${maxIterations} (difficulty=${difficulty})`
+  );
+}
+
+export function validateBlock(
+  block: Block,
+  previousBlock: Block,
+  difficulty = 2
+): { valid: boolean; reason?: string } {
+  if (block.index !== previousBlock.index + 1) {
+    return { valid: false, reason: "invalid_index" };
+  }
+
+  if (block.previousHash !== previousBlock.hash) {
+    return { valid: false, reason: "previous_hash_mismatch" };
+  }
+
+  const expectedHash = calculateBlockHash({
+    index: block.index,
+    previousHash: block.previousHash,
+    timestamp: block.timestamp,
+    transactions: block.transactions,
+    nonce: block.nonce,
+  });
+
+  if (block.hash !== expectedHash) {
+    return { valid: false, reason: "hash_mismatch" };
+  }
+
+  if (!block.hash.startsWith("0".repeat(difficulty))) {
+    return { valid: false, reason: "difficulty_not_met" };
+  }
+
+  return { valid: true };
+}
+
+export function validateChain(
+  chain: Block[],
+  difficulty = 2
+): { valid: boolean; failedAt?: number; reason?: string } {
+  if (chain.length === 0) {
+    return { valid: false, failedAt: 0, reason: "empty_chain" };
+  }
+
+  for (let i = 1; i < chain.length; i += 1) {
+    const result = validateBlock(chain[i], chain[i - 1], difficulty);
+    if (!result.valid) {
+      return { valid: false, failedAt: i, reason: result.reason };
+    }
+  }
+
+  return { valid: true };
+}


### PR DESCRIPTION
## What this PR adds

This draft PR provides a minimal, reviewable implementation for Issue #23 (block creation + validation process):

- `blockchain.ts`
  - block hash calculation
  - `mineBlock(...)` for PoW block construction
  - `validateBlock(...)` and `validateChain(...)`
- `blockchain-demo.ts`
  - mines two connected blocks and validates chain integrity
- README update with run instructions

## Why this scope

Kept intentionally small so maintainers can review the core block lifecycle before networking, mempool, or persistence concerns are added.

## Verification

```bash
bun run blockchain-demo.ts
```

Expected output: two mined blocks and `"validation": { "valid": true }`.

Closes #23
